### PR TITLE
implemented referal header add

### DIFF
--- a/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
+++ b/android/src/main/java/com/reactnativecommunity/webview/RNCWebViewManager.java
@@ -107,6 +107,7 @@ import javax.annotation.Nullable;
 public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
   public static String activeUrl = null;
+  public static String refererUrl = null;
   public static final int COMMAND_GO_BACK = 1;
   public static final int COMMAND_GO_FORWARD = 2;
   public static final int COMMAND_RELOAD = 3;
@@ -609,7 +610,13 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
         if (args == null) {
           throw new RuntimeException("Arguments for loading an url are null!");
         }
-        root.loadUrl(args.getString(0));
+
+        HashMap<String, String> headerMap = new HashMap<>();
+        if (refererUrl != null) {
+          headerMap.put("Referer", refererUrl);
+        }
+
+        root.loadUrl(args.getString(0), headerMap);
         break;
       case COMMAND_FOCUS:
         root.requestFocus();
@@ -742,6 +749,7 @@ public class RNCWebViewManager extends SimpleViewManager<WebView> {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
+      refererUrl = activeUrl;
       activeUrl = url;
       dispatchEvent(
         view,


### PR DESCRIPTION
Homesite OLS won't work consistently unless we send the referral header. Ideally, they will fix this on their side. However, it's completely blocking release of homeowners so we wanted to have this repo ready as a workaround.

Note that this is branched of 7.6.0, which is the version of react native web view that we use in the Root App.

see https://github.com/react-native-community/react-native-webview/pull/1200/files